### PR TITLE
chore(deps): upgrade github actions dependencies

### DIFF
--- a/.github/workflows/deployDestinationFunction.yml
+++ b/.github/workflows/deployDestinationFunction.yml
@@ -12,10 +12,10 @@ jobs:
     if: github.ref != 'refs/heads/main' || github.event.label.name == '!!_RELEASE_TO_QA'
     environment: DEV
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
       - name: Install NPM packages
@@ -29,8 +29,8 @@ jobs:
 #     if: github.event.label.name == '!!_RELEASE_TO_QA'
 #     environment: QA
 #     steps:
-#       - uses: actions/checkout@v3
-#       - uses: actions/setup-node@v3
+#       - uses: actions/checkout@v4
+#       - uses: actions/setup-node@v4
 #         with:
 #           node-version-file: '.nvmrc'
 #       - name: Install NPM packages
@@ -44,8 +44,8 @@ jobs:
 #     if: github.ref == 'refs/heads/main'
 #     environment: PROD
 #     steps:
-#       - uses: actions/checkout@v3
-#       - uses: actions/setup-node@v3
+#       - uses: actions/checkout@v4
+#       - uses: actions/setup-node@v4
 #         with:
 #           node-version-file: '.nvmrc'
 #       - name: Install NPM packages


### PR DESCRIPTION
**Before this PR:**
- `actions/checkout@v3` and `actions/setup-node@v3` are not up-to-date

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-node@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

**After this PR:**
- `actions/checkout@v3` → `actions/checkout@v4`
- `actions/setup-node@v3` → `actions/setup-node@v4`

**Reason that prompted this change:**
- Warnings were thrown about `actions/checkout@v3` and `actions/setup-node@v3` being outdated